### PR TITLE
Fixing Deprecation Warning

### DIFF
--- a/Scripts Python/TROTS_python_import_example.py
+++ b/Scripts Python/TROTS_python_import_example.py
@@ -33,11 +33,11 @@ c = None
 row_offset = 0
 num_aux_variables = 0
 for i in range(len(f['problem']['dataID'])):
-    data_id = int(get_h5py_struct_array_value(f, 'problem', 'dataID', i))
-    is_constraint = bool(get_h5py_struct_array_value(f, 'problem', 'IsConstraint', i))
-    minimize = bool(get_h5py_struct_array_value(f, 'problem', 'Minimise', i))
-    weight = float(get_h5py_struct_array_value(f, 'problem', 'Weight', i))
-    bound = float(get_h5py_struct_array_value(f, 'problem', 'Objective', i))
+    data_id = int(get_h5py_struct_array_value(f, 'problem', 'dataID', i)[0][0])
+    is_constraint = bool(get_h5py_struct_array_value(f, 'problem', 'IsConstraint', i)[0][0])
+    minimize = bool(get_h5py_struct_array_value(f, 'problem', 'Minimise', i)[0][0])
+    weight = float(get_h5py_struct_array_value(f, 'problem', 'Weight', i)[0][0])
+    bound = float(get_h5py_struct_array_value(f, 'problem', 'Objective', i)[0][0])
     
     factor = 1 if minimize else -1
     


### PR DESCRIPTION
Hi!

The lines 36 to 40 were prompting the following warning:

`DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)`

This is because they were trying to convert `numpy.ndarray` -> `Int`, `Bool`, or `Float`. The fix for this is to just index the number inside the numpy.ndarray first and then convert it.

Example: the return from the function in line 37 `get_h5py_struct_array_value(f, 'problem', 'dataID', I)` is `[ [2.] ]`

But if you just index it with [0][0] by doing `get_h5py_struct_array_value(f, 'problem', 'dataID', I)[0][0]` the return is `2.`

And then you convert it : )